### PR TITLE
Create and play with a custom query index for model homes #24

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,43 @@
+version: 1
+indices:
+  models:
+    include:
+      - '/drafts/bhellema/homes/**'
+    target: /model-query-index.json
+    properties:
+      price:
+        select: head > meta[name="price"]
+        value: attribute(el, 'content')
+      square-feet:
+        select: head > meta[name="square-feet"]
+        value: attribute(el, 'content')
+      beds:
+        select: head > meta[name="beds"]
+        value: attribute(el, 'content')
+      cars:
+        select: head > meta[name="cars"]
+        value:  attribute(el, 'content')
+      primary-bed:
+        select: head > meta[name="primary-bed"]
+        value:  attribute(el, 'content')
+      full-bed-on-first:
+        select: head > meta[name="full-bed-on-first"]
+        value: attribute(el, 'content')
+      full-bath-main:
+        select: head > meta[name="full-bath-main"]
+        value: attribute(el, 'content')
+      home-style:
+        select: head > meta[name="home-style"]
+        value: attribute(el, 'content')
+      status:
+        select: head > meta[name="status"]
+        value: attribute(el, 'content')
+      monthly-price:
+        select: head > meta[name="monthly-price"]
+        value: attribute(el, 'content')
+      mls:
+        select: head > meta[name="mls"]
+        value: attribute(el, 'content')
+      address:
+        select: head > meta[name="address"]
+        value: attribute(el, 'content')


### PR DESCRIPTION
Attempting to prototype a query index for model homes.  Trying to prototype what we can do with the query index and the model component. 

Fix #24

Test URLs:
Before: https://main--hubblehomes-com--aemsites.hlx.live/
After: https://query-index--hubblehomes-com--aemsites.hlx.page/