### PR TITLE
Fixed form layout at mobile view

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -316,6 +316,20 @@ footer {
       }
 
       ul { margin-left: 8% }
+
+      .col-2 {
+        padding-bottom: 200px;
+        form.subscribe {
+          text-align: center;
+          small { white-space: wrap }
+          input {
+            margin: 4px 0;
+            &.firstname, &.lastname { width: 100% }
+            &.email { width: 100%; border-radius: 4px; }
+            &.submit { border-radius: 4px; }
+          }
+        }
+      }
     }
     
     .bottom {
@@ -345,13 +359,6 @@ footer {
         &:empty { display: none }
       }
       .col-1, .col-2, .col-3 { width: auto }
-      .col-2 form.subscribe {
-        small { padding: 0 30px; white-space: wrap }
-        input {
-          &.email { width: 68% }
-          &.submit { width: calc(32% - 2px) }
-        }
-      }
     }
   }
 }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -324,9 +324,9 @@ footer {
           small { white-space: wrap }
           input {
             margin: 4px 0;
-            &.firstname, &.lastname { width: 100% }
-            &.email { width: 100%; border-radius: 4px; }
-            &.submit { border-radius: 4px; }
+            &.firstname, &.lastname, &.email { width: 100% }
+            &.email, &.submit { border-radius: 4px }
+            &.submit { min-width: 100px }
           }
         }
       }


### PR DESCRIPTION
Found a minor issue with the form fields when reviewing the footer (for mobile view at width < 700). 

Before:
![image](https://github.com/aemsites/hubblehomes-com/assets/138233107/ef8fcf60-3adf-4295-b0f9-c322ee53c84e)


After:
![image](https://github.com/aemsites/hubblehomes-com/assets/138233107/b52c6c06-b2b5-4f3f-a08d-d860e8be79b7)

Test URLs:

Before: https://main--hubblehomes-com--aemsites.hlx.live/drafts/dfink/blank-test-page
After: https://4-footer-mobile-update--hubblehomes-com--aemsites.hlx.live/drafts/dfink/blank-test-page
After: https://4-footer-mobile-update--hubblehomes-com--aemsites.hlx.live/news/news-detail/2020-bca-fall-parade-of-homes-31
