### PR TITLE
Add equivalent import JSON rules

### DIFF
--- a/tools/importer/communities-import.json
+++ b/tools/importer/communities-import.json
@@ -1,0 +1,80 @@
+{
+  "cleanup": {
+    "start": [
+      ".navholder",
+      "form",
+      "#chat-widget-container",
+      ".cd-top",
+      "#buttonClickModal",
+      "noscript",
+      "#communities",
+      ".homesearchform",
+      ".container > .row > .col-sm-12 > .btn-group",
+      ".container > .row > .col-sm-12 > small > a",
+      ".container > .row > .topbuffer",
+      ".modal",
+      ".graydivider",
+      ":scope > img",
+      "#inventoryshowhide"
+    ],
+    "end": [
+      ".breadcrumb",
+      "#skiptocontent",
+      ".footerrow",
+      ".subfooter",
+      ".sidebar",
+      ".sharethis-inline-share-buttons",
+      ".mobile-footer",
+      ".modal-footer"
+    ]
+  },
+  "blocks": [
+    {
+      "type": "metadata",
+      "insertMode": "append",
+      "params": {
+        "cells": {
+          "Template": "community",
+          "PublishedDate": [[".text-center small strong", ".text-center small strong:first-child + ::text", { "replace": ["\\|"] }]]
+        }
+      }
+    },
+    {
+      "type": "carousel",
+      "variants": ["auto-2000"],
+      "selectors": [
+        ".homesearchmapwrapper:has(#myCarousel)"
+      ],
+      "params": {
+        "cells": [
+          ["Default Slide Text (optional)", ["<h2>{{.communitytitle-top #communitytitle-1}}</h2>{{.communitytitle-top #communitytitle-2}}<hr><h2>{{.communitytitle-bottom #communitytitle-3}}</h2>{{.communitytitle-bottom #communitytitle-4}}"]]
+        ]
+      }
+    },
+    {
+      "type": "columns",
+      "variants": ["About"],
+      "selectors": [
+        ".row .row:has(.panel-group)"
+      ],
+      "params": {
+        "cells": ".panel-group"
+      }
+    },
+    {
+      "type": "video",
+      "selectors": [
+        ".video-container:has(iframe)"
+      ],
+      "params": {
+        "cells": {
+          "URL": "iframe[src]",
+          "Type": [
+            ["iframe[type]", "iframe[type]"],
+            ["*", "video"]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tools/importer/news-detail-import.json
+++ b/tools/importer/news-detail-import.json
@@ -1,0 +1,75 @@
+{
+  "cleanup": {
+    "start": [
+      ".navholder",
+      "#skiptocontent",
+      ".footerrow",
+      ".subfooter",
+      ".sidebar",
+      ".sharethis-inline-share-buttons",
+      "form",
+      "#chat-widget-container",
+      ".mobile-footer",
+      ".modal-footer",
+      ".cd-top",
+      "#buttonClickModal",
+      "noscript",
+      ".homesearchmapwrapper"
+    ],
+    "end": [
+      ".breadcrumb",
+      ":scope > img",
+      "img[width=\"0\"][height=\"0\"]",
+      ".text-center small:has(strong)",
+      "small strong ::text(Tags:)",
+      "div.col-sm-9.sidebarbody ::text(By Hubble Homes, LLC)",
+      "h3 ::text(Leave a reply)"
+    ]
+  },
+  "blocks": [
+    {
+      "type": "metadata",
+      "insertMode": "append",
+      "params": {
+        "cells": {
+          "Template": [
+            [".breadcrumb a[href*=\"news\"]", "news"]
+          ],
+          "PublishedDate": [[".text-center small strong", ".text-center small strong:first-child + ::text", { "replace": ["\\|"] }]],
+          "Categories": [[".text-center small strong", ".text-center small strong:last-child + ::text", { "replace": ["\\s*\\|\\s*", ", "] }]]
+        }
+      }
+    },
+    {
+      "type": "carousel",
+      "selectors": [
+        "#myCarousel"
+      ]
+    },
+    {
+      "type": "columns",
+      "variants": ["About"],
+      "selectors": [
+        ".row .row:has(.panel-group)"
+      ],
+      "params": {
+        "cells": ".panel-group"
+      }
+    },
+    {
+      "type": "video",
+      "selectors": [
+        ".video-container:has(iframe)"
+      ],
+      "params": {
+        "cells": {
+          "URL": "iframe[src]",
+          "Type": [
+            ["iframe[type]", "iframe[type]"],
+            ["*", "video"]
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Import JSON is a new experimental feature that allows imports to be performed without writing any code. This feature is currently available in a branch of the [helix-importer-ui](https://github.com/arumsey/helix-importer-ui/tree/import-as-a-service).

- https://github.com/arumsey/helix-importer-ui/blob/import-as-a-service/importer-declarative.md

The import JSON format is included within the larger **[Express Import](https://github.com/adobe/helix-importer-ui/issues/355)** feature that provides an option to visually map a source URL to a strucutre that is compatible with Edge Delivery.

<img width="1970" alt="image" src="https://github.com/aemsites/hubblehomes-com/assets/1004204/6aadff53-c138-4d34-ac2d-174443c98acf">

