### PR TITLE
Generate a Breadcrumb trail based on page location

### DIFF
--- a/scripts/breadcrumbs.js
+++ b/scripts/breadcrumbs.js
@@ -1,0 +1,68 @@
+import { fetchPageIndex } from './pages.js';
+import {
+  a, div, li, span, ul,
+} from './dom-helpers.js';
+
+export default async function buildBreadcrumbs() {
+  const { data } = await fetchPageIndex();
+
+  const { pathname } = window.location;
+  const pathParts = pathname.split('/').filter((part) => part);
+
+  let currentPath = '';
+  const breadcrumbItems = [];
+
+  // Helper function to find all page names by path
+  function getPageNamesByPath(path) {
+    return data.filter((page) => page.path === path).map((page) => page['page name']);
+  }
+
+  const homeLink = a({ href: '/' }, 'Home');
+  const homeCrumb = li(homeLink);
+  const crumbList = ul({ class: 'breadcrumbs' }, homeCrumb);
+  const breadcrumbContainer = div({ class: 'section' }, crumbList);
+
+  pathParts.forEach((part, index) => {
+    currentPath += `/${part}`;
+    const pageNames = getPageNamesByPath(currentPath);
+
+    if (pageNames.length === 0) return;
+
+    // Check if the last breadcrumb item has the same name as the current segment
+    const lastBreadcrumb = breadcrumbItems[breadcrumbItems.length - 1];
+    const isParentSameAsChild = lastBreadcrumb && lastBreadcrumb.textContent === pageNames[0];
+
+    if (isParentSameAsChild) {
+      breadcrumbItems.pop(); // Remove the last item if parent and child names are the same
+    }
+
+    // Add all page names found for the current path
+    pageNames.forEach((pageName, idx) => {
+      const liEl = li();
+      let link = a();
+
+      // Set the href for all but the last part
+      if (index < pathParts.length - 1 || idx < pageNames.length - 1) {
+        link.setAttribute('href', currentPath);
+      } else {
+        link = span();
+      }
+
+      link.textContent = pageName;
+      liEl.appendChild(link);
+      breadcrumbItems.push(liEl);
+    });
+  });
+
+  if (breadcrumbItems.length > 0) {
+    // Append all breadcrumb items to the container if there are more than one
+    breadcrumbItems.forEach((item) => {
+      crumbList.appendChild(item);
+    });
+  } else {
+    // if we're on the root page, display no breadcrumbs
+    breadcrumbContainer.style.display = 'none';
+  }
+
+  return breadcrumbContainer;
+}

--- a/scripts/pages.js
+++ b/scripts/pages.js
@@ -1,0 +1,12 @@
+async function fetchPageIndex() {
+  const request = await fetch('/data/page-index.json');
+  if (request.ok) {
+    return request.json();
+  }
+  throw new Error('Failed to fetch workbook');
+}
+
+export {
+  // eslint-disable-next-line import/prefer-default-export
+  fetchPageIndex,
+};

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -192,6 +192,7 @@
 
   /* links */
   a:any-link {
+    color: var(--link-color);
     text-decoration: none;
     font-weight: 600;
   }
@@ -240,20 +241,35 @@
     margin: 20px 0;
   }
 
-
   .breadcrumbs {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
     font-size: .8em;
     color: #c8c8c8;
     padding: 8px 0;
     user-select: none;
 
-    a {
-      color: #aaa;
-      text-decoration: none;
-    }
+    li {
+      margin: 10px 1px;
 
-    &:hover {
-      color: #0055b9;
+      &::after {
+        content: ">";
+        margin-left: 5px;
+      }
+
+      &:last-child::after {
+        content: "";
+      }
+
+      a {
+        color: #aaa;
+        text-decoration: none;
+
+        &:hover {
+          color: #0055b9;
+        }
+      }
     }
   }
 
@@ -309,10 +325,6 @@
     font-weight: 400;
     color: var(--link-color);
     padding-top: 30px !important;
-
-    a:any-link {
-      color: var(--link-color);
-    }
   }
 
   .strike-through {

--- a/templates/about-us/about-us.css
+++ b/templates/about-us/about-us.css
@@ -1,0 +1,6 @@
+.about-us {
+  .btn-container {
+    margin-top: 50px;
+    justify-content: center;
+  }
+}

--- a/templates/about-us/about-us.js
+++ b/templates/about-us/about-us.js
@@ -1,0 +1,5 @@
+import { loadTemplate } from '../../scripts/scripts.js';
+
+export default async function decorate(doc) {
+  await loadTemplate(doc, 'default');
+}

--- a/templates/communities/communities.js
+++ b/templates/communities/communities.js
@@ -27,6 +27,7 @@ import DeferredPromise from '../../scripts/deferred.js';
 import formatPhoneNumber from '../../scripts/phone-formatter.js';
 import loadSVG from '../../scripts/svg-helper.js';
 import { loadWorkbook } from '../../scripts/workbook.js';
+import { loadTemplate } from '../../scripts/scripts.js';
 
 /**
  * Builds the inventory homes block.
@@ -91,23 +92,6 @@ async function createSpecialists(specialists) {
   Promise.all(promises)
     .then(() => deferred.resolve(agents));
   return deferred.promise;
-}
-
-function buildBreadCrumbs() {
-  return div(
-    { class: 'breadcrumbs section' },
-    a({
-      href: '/',
-      'arial-label': 'View Home Page',
-    }, 'Home'),
-    ' > ',
-    a({
-      href: '/foo',
-      'arial-label': 'View News Page',
-    }, 'CommunityName'),
-    ' > ',
-    'XXX',
-  );
 }
 
 async function createRightAside(doc, salesCenter) {
@@ -249,6 +233,8 @@ function buildFilterForm(filterByValue) {
 }
 
 export default async function decorate(doc) {
+  await loadTemplate(doc, 'default');
+
   const url = new URL(window.location);
   const params = url.searchParams;
   const filter = params.get('filter');
@@ -274,7 +260,6 @@ export default async function decorate(doc) {
     href: `/contact-us/sales-info?communityid=${community.name}`,
   }, 'Request Information'));
 
-  const breadCrumbsEl = buildBreadCrumbs();
   const overview = doc.querySelector('.overview-wrapper');
   const tabsWrapper = doc.querySelector('.tabs-wrapper');
   const rightAside = await createRightAside(doc, salesCenter);
@@ -315,7 +300,6 @@ export default async function decorate(doc) {
   ));
 
   mainSection.append(
-    breadCrumbsEl,
     leftRight,
     modelFilter,
     plansAnchor,

--- a/templates/default/default.css
+++ b/templates/default/default.css
@@ -13,8 +13,6 @@
 
   .btn-container {
     display: flex;
-    justify-content: center;
-    margin-top: 30px;
   }
 
   div.breadcrumbs {

--- a/templates/default/default.js
+++ b/templates/default/default.js
@@ -1,14 +1,9 @@
-import { div, a } from '../../scripts/dom-helpers.js';
+import buildBreadcrumbs from '../../scripts/breadcrumbs.js';
 
 export default async function decorate(doc) {
   const mainSection = doc.querySelector('main > .section');
 
-  const $breadCrumbs = div(
-    { class: 'breadcrumbs' },
-    a({ href: '/', 'arial-lable': 'View Home Page' }, 'Home'),
-    ' > ',
-    '--- PAGE ---',
-  );
+  const $breadCrumbs = await buildBreadcrumbs();
 
   const $carousel = mainSection.querySelector('.carousel-wrapper');
   if ($carousel) {

--- a/templates/home-plan/home-plan.js
+++ b/templates/home-plan/home-plan.js
@@ -1,7 +1,6 @@
 import {
   aside,
   div,
-  a,
   h4,
   h1, br,
 } from '../../scripts/dom-helpers.js';
@@ -13,22 +12,12 @@ import { buildBlock, decorateBlock } from '../../scripts/aem.js';
 import { loadTemplateBlock } from '../../scripts/template-block.js';
 import { getSalesCenterForCommunity } from '../../scripts/sales-center.js';
 import { loadRates } from '../../scripts/mortgage.js';
+import { loadTemplate } from '../../scripts/scripts.js';
 
 async function fetchRequiredPageData() {
   await loadWorkbook();
   await loadRates();
   return getHomePlanByPath(window.location.pathname);
-}
-
-function buildBreadCrumbs() {
-  return div(
-    { class: 'breadcrumbs section' },
-    a({ href: '/', 'aria-label': 'View Home Page' }, 'Home'),
-    ' > ',
-    a({ href: '/foo', 'aria-label': 'View News Page' }, 'CommunityName'),
-    ' > ',
-    '-- TO BE UPDATED --',
-  );
 }
 
 async function createRightAside(doc, homePlan) {
@@ -74,8 +63,8 @@ async function buildAccordion(model) {
 }
 
 export default async function decorate(doc) {
+  await loadTemplate(doc, 'default');
   const homePlan = await fetchRequiredPageData();
-  const breadCrumbsEl = buildBreadCrumbs();
   const rightAside = await createRightAside(doc, homePlan);
 
   const mainSectionEl = doc.querySelector('main > .section');
@@ -125,7 +114,6 @@ export default async function decorate(doc) {
 
   safeAppend(
     mainSectionEl,
-    breadCrumbsEl,
     leftRight,
     elevations,
     actionButtons,

--- a/templates/inventory/inventory.js
+++ b/templates/inventory/inventory.js
@@ -25,6 +25,7 @@ import {
   buildBlock, decorateBlock,
 } from '../../scripts/aem.js';
 import { loadTemplateBlock } from '../../scripts/template-block.js';
+import { loadTemplate } from '../../scripts/scripts.js';
 
 async function fetchRequiredPageData() {
   await loadWorkbook();
@@ -38,17 +39,6 @@ async function fetchRequiredPageData() {
     homeDetails,
     phoneNumber: phone,
   };
-}
-
-function buildBreadCrumbs() {
-  return div(
-    { class: 'breadcrumbs section' },
-    a({ href: '/', 'aria-label': 'View Home Page' }, 'Home'),
-    ' > ',
-    a({ href: '/foo', 'aria-label': 'View News Page' }, 'CommunityName'),
-    ' > ',
-    'The Birch',
-  );
 }
 
 async function buildInventoryCards(inventoryHomes, community) {
@@ -101,9 +91,10 @@ async function createPricingInformation(homeDetails) {
 }
 
 export default async function decorate(doc) {
+  await loadTemplate(doc, 'default');
+
   const { homeDetails, phoneNumber } = await fetchRequiredPageData();
 
-  const breadCrumbsEl = buildBreadCrumbs();
   const rightAside = await createRightAside(doc, homeDetails, phoneNumber);
 
   const mainSectionEl = doc.querySelector('main > .section');
@@ -163,7 +154,6 @@ export default async function decorate(doc) {
 
   safeAppend(
     mainSectionEl,
-    breadCrumbsEl,
     leftRight,
     elevations,
     actionButtons,

--- a/templates/model/model.js
+++ b/templates/model/model.js
@@ -1,7 +1,6 @@
 import {
   aside,
   div,
-  a,
   h4,
   h1, br,
 } from '../../scripts/dom-helpers.js';
@@ -13,22 +12,12 @@ import { loadTemplateBlock } from '../../scripts/template-block.js';
 import { getSalesCenterForCommunity } from '../../scripts/sales-center.js';
 import { loadRates } from '../../scripts/mortgage.js';
 import { getModelByPath } from '../../scripts/models.js';
+import { loadTemplate } from '../../scripts/scripts.js';
 
 async function fetchRequiredPageData() {
   await loadWorkbook();
   await loadRates();
   return getModelByPath(window.location.pathname);
-}
-
-function buildBreadCrumbs() {
-  return div(
-    { class: 'breadcrumbs section' },
-    a({ href: '/', 'aria-label': 'View Home Page' }, 'Home'),
-    ' > ',
-    a({ href: '/foo', 'aria-label': 'View News Page' }, 'CommunityName'),
-    ' > ',
-    '-- TO BE UPDATED --',
-  );
 }
 
 async function createRightAside(doc, homePlan) {
@@ -74,8 +63,8 @@ async function buildAccordion(model) {
 }
 
 export default async function decorate(doc) {
+  await loadTemplate(doc, 'default');
   const homePlan = await fetchRequiredPageData();
-  const breadCrumbsEl = buildBreadCrumbs();
   const rightAside = await createRightAside(doc, homePlan);
 
   const mainSectionEl = doc.querySelector('main > .section');
@@ -126,7 +115,6 @@ export default async function decorate(doc) {
 
   safeAppend(
     mainSectionEl,
-    breadCrumbsEl,
     leftRight,
     elevations,
     actionButtons,


### PR DESCRIPTION
Fix #57 

Test URLs:
- Before: https://main--hubblehomes-com--aemsites.hlx.page/about-us
- After: https://issue-57--hubblehomes-com--aemsites.hlx.page/about-us
- After: https://issue-57--hubblehomes-com--aemsites.hlx.page/new-homes/idaho/boise-metro/nampa/adams-ridge/maple-loft/10418-rockaway-ridge-st/999

* keep styling for default page generic
* generate breadcrumb for page that have been published and have the "Page Name" property in the metadata.