### PR TITLE
[Bug] Top Banner close button changes to Oval on Hubble Home for Hero…

### DIFF
--- a/styles/buttons.css
+++ b/styles/buttons.css
@@ -163,6 +163,7 @@
   /* Unicode for multiplication sign, looks like an "x" */
   &.close {
     height: 32px;
+    flex: 0;
   }
 
   &.close::before {


### PR DESCRIPTION

Fix #248  

Test URLs:
- Before: https://main--hubblehomes-com--aemsites.hlx.page/promotions/promotions-detail/hubble-homes-for-heroes
- After: https://issue-248--hubblehomes-com--aemsites.hlx.page/promotions/promotions-detail/hubble-homes-for-heroes
