### PR TITLE
issue-339

### DIFF
--- a/templates/news-detail/news-detail.css
+++ b/templates/news-detail/news-detail.css
@@ -8,20 +8,28 @@
   margin: 0 auto;
 }
 
-.news-detail, .news-landing {
+.news-detail,
+.news-landing {
   .content-wrapper {
     .default-content-wrapper picture {
       float: right;
     }
 
+    .default-content-wrapper a {
+      color: var(--blue);
+    }
+
     /* reverse order so filter is displayed at the top */
-    @media (width <= 991px) {
+    @media (width <=991px) {
       display: flex;
       flex-direction: column-reverse;
 
       aside {
         text-align: center;
-        hr { display: none }
+
+        hr {
+          display: none
+        }
 
         /* select list styling */
         .select {
@@ -46,7 +54,10 @@
               scale: .6;
               transform: rotate(90deg);
             }
-            .active &::after { transform: rotate(-90deg) }
+
+            .active &::after {
+              transform: rotate(-90deg)
+            }
           }
 
           .filter {
@@ -61,14 +72,19 @@
             transition: all 400ms ease-in-out;
             text-align: left;
             text-wrap: nowrap;
-            .active & { max-height: 100vh }
+
+            .active & {
+              max-height: 100vh
+            }
 
             li {
               padding: 2px 10px;
             }
           }
 
-          hr { display: none }
+          hr {
+            display: none
+          }
         }
       }
     }
@@ -89,7 +105,9 @@
   .recent-news li {
     margin: 16px 0;
   }
-} /* .news-detail */
+}
+
+/* .news-detail */
 
 
 
@@ -108,11 +126,14 @@
 
     a {
       color: var(--text-color);
-      &:hover { color: var(--blue) }
+
+      &:hover {
+        color: var(--blue)
+      }
     }
   }
 
-  > div {
+  >div {
     display: flex;
     flex-direction: column;
     gap: 40px;


### PR DESCRIPTION
Fix #339

Test URLs:
- Before: https://main--hubblehomes-com--aemsites.hlx.page/news/news-detail/building-a-greener-future-hubble-homes-receives-2024-energy-star-market-leader-award-161
- After: https://issue-339--hubblehomes-com--aemsites.hlx.page/news/news-detail/building-a-greener-future-hubble-homes-receives-2024-energy-star-market-leader-award-161