### PR TITLE
remove btn and fancy from the link

### DIFF
--- a/blocks/links/links.js
+++ b/blocks/links/links.js
@@ -5,6 +5,7 @@ export default function decorate(block) {
   block.innerHTML = '';
   const linksDiv = div('Links:');
   links.forEach((link) => {
+    link.classList.remove('btn', 'fancy');
     link.setAttribute('target', '_blank');
     linksDiv.appendChild(link);
   });


### PR DESCRIPTION
Fix #368 

Test URLs:
- Before: https://main--hubblehomes-com--aemsites.aem.live/new-homes/idaho/boise-metro/mountain-home/silverstone-north
- After: https://issue-368--hubblehomes-com--aemsites.aem.live/new-homes/idaho/boise-metro/mountain-home/silverstone-north
